### PR TITLE
fix: replace broken star history chart with working alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,4 +373,4 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 ## 📅 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=InternScience/GraphGen&type=Date)](https://www.star-history.com/#InternScience/GraphGen&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=InternScience/GraphGen&type=Date)](https://star-history.dera.page/#InternScience/GraphGen&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -373,5 +373,5 @@ GraphGen 首先根据源文本构建细粒度的知识图谱，然后利用期�
 
 ## 📅 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=InternScience/GraphGen&type=Date)](https://www.star-history.com/#InternScience/GraphGen&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=InternScience/GraphGen&type=Date)](https://star-history.dera.page/#InternScience/GraphGen&Date)
 


### PR DESCRIPTION
The star history chart was broken due to GitHub stargazer API restrictions. This fix replaces the endpoint with star-history.dera.page, which uses a different data source that does not require an API token.

This is the same approach already adopted by many other projects including Snailclimb/JavaGuide and langgenius/dify.